### PR TITLE
Corrects color of odd table rows

### DIFF
--- a/themes/whiteboard/source/css/style.styl
+++ b/themes/whiteboard/source/css/style.styl
@@ -351,7 +351,7 @@ embossed-bg()
     tr:last-child
       border-bottom: 1px solid #ccc
     tr:nth-child(odd) > td
-      background-color: lighten($main-bg, 4.2%)
+      background-color: darken($main-bg, 4.2%)
     tr:nth-child(even) > td
       background-color: lighten($main-bg, 2.4%)
   dt


### PR DESCRIPTION
This PR fixes issue #17.

Instead of using lighten, I changed to darken function in order to make the "stripped" table effect more visible.