### PR TITLE
Add language specific parts in content

### DIFF
--- a/themes/whiteboard/source/js/script.js
+++ b/themes/whiteboard/source/js/script.js
@@ -30,8 +30,10 @@ under the License.
     $(".lang-selector a[data-language-name='" + language + "']").addClass('active');
     for (var i=0; i < languages.length; i++) {
       $(".highlight." + languages[i]).parent().hide();
+      $(".lang-specific." + languages[i]).hide();
     }
     $(".highlight." + language).parent().show();
+    $(".lang-specific." + language).show();
 
     global.toc.calculateHeights();
 


### PR DESCRIPTION
Just use <span class="lang-specific python">All content here will be displayed only for shell python</span> to display text only for a specific content
Ref. https://github.com/lord/slate/issues/722